### PR TITLE
Change TERM value to vt220

### DIFF
--- a/bin/server.py
+++ b/bin/server.py
@@ -122,7 +122,7 @@ class TermSocketHandler(RPCServer):
                 'COLUMNS': str(cols),
                 'LINES': str(rows),
                 'PATH': os.environ['PATH'],
-                'TERM': 'linux',
+                'TERM': 'vt220',
             }
             os.execvpe(cmd[0], cmd, env)
         else:  # parent process


### PR DESCRIPTION
Ubuntu Bionic, _currently_ the only OS which can be tested via Orion, has this value of the `TERM` environment variable.